### PR TITLE
btrfs send takes options before arguments

### DIFF
--- a/bin/snap-sync
+++ b/bin/snap-sync
@@ -342,7 +342,7 @@ for x in $selected_configs; do
         # backup location. Using the -c flag instead of -p tells it that there
         # is an identical subvolume to the old snapshot at the receiving
         # location where it can get its data. This helps speed up the transfer.
-        btrfs send "$new_snap" -c "$old_snap" | $ssh btrfs receive "$backup_location"
+        btrfs send -c "$old_snap" "$new_snap" | $ssh btrfs receive "$backup_location"
         printf "Deleting old snapshot for $x...\n" | tee $PIPE
         snapper -c "$x" delete "$old_num"
     fi


### PR DESCRIPTION
btrfs-progs 4.11 includes this patch[0] which has updated the option
parser which has enforced the order in which arguments and options
appear in. See this email for context[1]

[0]: https://git.kernel.org/pub/scm/linux/kernel/git/kdave/btrfs-progs.git/commit/?id=010ceab56e067b87ea282fde6ff792c1ceefd7dc
[1]: https://www.mail-archive.com/linux-btrfs@vger.kernel.org/msg62226.html

fixes https://github.com/wesbarnett/snap-sync/issues/32

Thank you [Tsutomu Itoh](https://marc.info/?l=linux-btrfs&m=149603595632559&w=2) for pointing this out.