### PR TITLE
Use a decent alternative for `/etc/conf.d/snapper`

### DIFF
--- a/bin/snap-sync
+++ b/bin/snap-sync
@@ -209,7 +209,7 @@ fi
 if [[ -f /etc/conf.d/snapper ]]; then
     source /etc/conf.d/snapper 
 else
-    die "/etc/conf.d/snapper does not exist!"
+    SNAPPER_CONFIGS=$(echo $(ls /etc/snapper/configs))
 fi
 
 selected_configs=${selected_configs:-$SNAPPER_CONFIGS}


### PR DESCRIPTION
Use a decent fallback if `/etc/conf.d/snapper` does not exist, by considering all available snapper configurations.

On some installations (like mine on ubuntu) the `/etc/conf.d/snapper` file doesn't exist. By using all available configurations in the snapper config file folder, the tool also works on those systems.