### PR TITLE
TARGETS not being correctly excluded if root filesystem is btrfs.

### DIFF
--- a/bin/snap-sync
+++ b/bin/snap-sync
@@ -162,7 +162,7 @@ fi
 if [[ "$(findmnt -n -v --target / -o FSTYPE)" == "btrfs" ]]; then
     EXCLUDE_UUID=$(findmnt -n -v -t btrfs --target / -o UUID)
     TARGETS=$($ssh findmnt -n -v -t btrfs -o UUID,TARGET --list | grep -v $EXCLUDE_UUID | awk '{print $2}')
-    UUIDS=$($ssh findmnt -n -v -t btrfs -o UUID,TARKET --list | grep -v $EXCLUDE_UUID | awk '{print $1}')
+    UUIDS=$($ssh findmnt -n -v -t btrfs -o UUID,TARGET --list | grep -v $EXCLUDE_UUID | awk '{print $1}')
 else
     TARGETS=$($ssh findmnt -n -v -t btrfs -o TARGET --list)
     UUIDS=$($ssh findmnt -n -v -t btrfs -o UUID --list)

--- a/bin/snap-sync
+++ b/bin/snap-sync
@@ -161,8 +161,8 @@ fi
 
 if [[ "$(findmnt -n -v --target / -o FSTYPE)" == "btrfs" ]]; then
     EXCLUDE_UUID=$(findmnt -n -v -t btrfs --target / -o UUID)
-    TARGETS=$($ssh findmnt -n -v -t btrfs -o TARGET --list | grep -v $EXCLUDE_UUID)
-    UUIDS=$($ssh findmnt -n -v -t btrfs -o UUID --list | grep -v $EXCLUDE_UUID)
+    TARGETS=$($ssh findmnt -n -v -t btrfs -o UUID,TARGET --list | grep -v $EXCLUDE_UUID | awk '{print $2}')
+    UUIDS=$($ssh findmnt -n -v -t btrfs -o UUID,TARKET --list | grep -v $EXCLUDE_UUID | awk '{print $1}')
 else
     TARGETS=$($ssh findmnt -n -v -t btrfs -o TARGET --list)
     UUIDS=$($ssh findmnt -n -v -t btrfs -o UUID --list)


### PR DESCRIPTION
See commit 69f388d for details. The bug manifested in my setup as listing the correct UUID of the non-system drive with the mountpoint of /, when that is obviously not correct. I then had to use the --UUID option when setting up snap-sync because it wouldn't recognize the UUID of the non-system drive. Further, I had to specify the full path (path relative to /) for the backup folder since it thought that the mount point was /.