### PR TITLE
Remove makefile systemd install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,4 +27,3 @@ SYSTEMD_DIR = $(DESTDIR)$(PREFIX)/lib/systemd/system
 install:
 	@./find_snapper_config || sed -i 's@^SNAPPER_CONFIG.*@SNAPPER_CONFIG='$(SNAPPER_CONFIG)'@g' bin/$(PKGNAME)
 	@install -Dm755 bin/* -t $(BIN_DIR)/
-	@install -Dm644 systemd/* -t $(SYSTEMD_DIR)/


### PR DESCRIPTION
Fixes a ``make install`` error due to missing directory.
Caused by the systemd script removal in commit 38caa9c

Please note that the user will still have to manually clean-up previously installed systemd scripts from the system directory.