### PR TITLE
Fix notification duplication

### DIFF
--- a/bin/snap-sync
+++ b/bin/snap-sync
@@ -50,7 +50,7 @@ if [[ $? -ne 0 ]]; then
 fi
 
 notify() {
-    for u in $(users | sed 's/ /\n/' | sort -u); do
+    for u in $(users | sed 's/ /\n/g' | sort -u); do
         sudo -u $u DISPLAY=:0 \
         DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$(sudo -u $u id -u)/bus \
         notify-send -a $name "$1" "$2" --icon="dialog-$3"


### PR DESCRIPTION
On my machine (with >3= instances of my user logged in),  the `sed` only replaces the first occurrence of space. This gives the following output:

```
user
user user
```

Since `user` and `user user` are not the same thing, `sort -u` does not remove the duplicates. This results in me being notified 3 times for all notifications. Replacing the spaces globally should fix this.