### PR TITLE
Switch rsync to use new-compress option

### DIFF
--- a/bin/snap-sync
+++ b/bin/snap-sync
@@ -459,9 +459,9 @@ for x in $selected_configs; do
         cp "$new_info" "$backup_location"
     else
         if [[ -z $port ]]; then
-            rsync -avzq "$new_info" "$remote":"$backup_location"
+            rsync -avzzq "$new_info" "$remote":"$backup_location"
         else
-            rsync -avzqe "ssh -p $port" "$new_info" "$remote":"$backup_location"
+            rsync -avzzqe "ssh -p $port" "$new_info" "$remote":"$backup_location"
         fi
     fi
 


### PR DESCRIPTION
On 2020-01-15 Arch Linux dropped support for old style -z|--old-compress
option [1] and errors out when trying to use it. Only new style
compression is supported using -zz|--new-compress options.

New style compression was added to rsync in version 3.1.1, released on
2014-05-22, [2] and is available on most Linux distributions.

Switching to the new compress option fixes compatibility issues with
Arch Linux and does not break anything for distributions that have
rsync 3.1.1 or newer.

[1]: https://www.archlinux.org/news/rsync-compatibility/
[2]: https://download.samba.org/pub/rsync/src/rsync-3.1.1-NEWS