### PR TITLE
Use sudo on remote

### DIFF
--- a/bin/snap-sync
+++ b/bin/snap-sync
@@ -204,7 +204,7 @@ declare -a SUBVOLIDS_ARRAY
 
 i=0
 for x in $TARGETS; do
-    SUBVOLIDS_ARRAY[$i]=$($ssh btrfs subvolume show $x | awk '/Subvolume ID:/ { print $3 }')
+    SUBVOLIDS_ARRAY[$i]=$($ssh sudo btrfs subvolume show $x | awk '/Subvolume ID:/ { print $3 }')
     TARGETS_ARRAY[$i]=$x
     i=$((i+1))
 done
@@ -339,7 +339,7 @@ for x in $selected_configs; do
         read -e -r -p "Enter name of subvolume to store backups, relative to $selected_mnt (to be created if not existing): " mybackupdir
         printf "This will be the initial backup for snapper configuration '%s' to this disk. This could take awhile.\n" "$x"
         BACKUPDIR="$selected_mnt/$mybackupdir"
-        $ssh test -d "$BACKUPDIR" || $ssh btrfs subvolume create "$BACKUPDIR"
+        $ssh test -d "$BACKUPDIR" || $ssh sudo btrfs subvolume create "$BACKUPDIR"
     else
         mybackupdir=$(snapper -c "$x" list -t single | awk -F"|" '/'"subvolid=$selected_subvolid, uuid=$selected_uuid"'/ {print $5}' | awk -F "," '/backupdir/ {print $1}' | awk -F"=" '{print $2}')
         BACKUPDIR="$selected_mnt/$mybackupdir"
@@ -440,7 +440,7 @@ for x in $selected_configs; do
 
     if [[ -z "$old_num" ]]; then
         printf "Sending first snapshot for '%s' configuration...\n" "$x" | tee $PIPE  
-        btrfs send "$new_snap" | $ssh btrfs receive "$backup_location" &>/dev/null
+        btrfs send "$new_snap" | $ssh sudo btrfs receive "$backup_location" &>/dev/null
 
     else
 
@@ -450,7 +450,7 @@ for x in $selected_configs; do
         # is an identical subvolume to the old snapshot at the receiving
         # location where it can get its data. This helps speed up the transfer.
 
-        btrfs send -c "$old_snap" "$new_snap" | $ssh btrfs receive "$backup_location"
+        btrfs send -c "$old_snap" "$new_snap" | $ssh sudo btrfs receive "$backup_location"
         printf "Modifying data for old local snapshot for '%s' configuration...\n" "$x" | tee $PIPE
         snapper -v -c "$x" modify -d "old snap-sync snapshot (you may remove)" -u "backupdir=,subvolid=,uuid=" -c "number" "$old_num"
     fi


### PR DESCRIPTION
It is often undesirable to allow the root user be accessed over SSH. The alternative is to add `$USER ALL=(ALL) NOPASSWD: /usr/bin/btrfs` so that the regular user can use `sudo btrfs` commands. How much safer is this? Probably not much, since an attacker could still `btrfs send` the files over the network or simply `btrfs subvolume delete` all your data. At least, this should keep your non-btrfs partitions safe(r). The only disadvantage I see is that this requires `sudo` to be installed.

Alternatively, I think using `PermitRootLogin prohibit-password` on the SSH configurations and using keys might work as well, but I like having the password as a way to remind me "hey, you could really mess things up".

~~What I haven't tested yet, is whether I could use `btrfs receive` as a regular user if my user owns the subvolume. This would allow us only require root privileges when the subvolumes are being created.~~ Nevermind, doesn't work. `btrfs receive` requires root privileges.