### PR TITLE
Fix detecting backup directory with recent snapper

### DIFF
--- a/bin/snap-sync
+++ b/bin/snap-sync
@@ -366,7 +366,7 @@ for x in $selected_configs; do
         BACKUPDIR="$selected_mnt/$mybackupdir"
         $ssh test -d "$BACKUPDIR" || $ssh btrfs subvolume create "$BACKUPDIR"
     else
-        mybackupdir=$(snapper -c "$x" list -t single | awk -F"|" '/'"subvolid=$selected_subvolid, uuid=$selected_uuid"'/ {print $5}' | awk -F "," '/backupdir/ {print $1}' | awk -F"=" '{print $2}')
+        mybackupdir=$(snapper -c "$x" list -t single | grep "subvolid=$selected_subvolid, uuid=$selected_uuid" | sed -E 's/.*backupdir=([^,]*).*/\1/')
         BACKUPDIR="$selected_mnt/$mybackupdir"
         $ssh test -d $BACKUPDIR || die "%s is not a directory on %s.\n" "$BACKUPDIR" "$selected_uuid"
     fi


### PR DESCRIPTION
Backup directory of an already-backed-up configuration is not being parsed and detected. I am using Manjaro Linux. Snapper is version 0.12.1. Output of `sudo snapper -c home list -t single` is:

```
  # │ Date                             │ User │ Description               │ Userdata
────┼──────────────────────────────────┼──────┼───────────────────────────┼────────────────────────────────────────────────────────────────────────────
  0 │                                  │ root │ current                   │
  2 │ Sun 05 Jan 2025 11:00:22 PM WITA │ root │ timeline                  │
655 │ Tue 18 Mar 2025 10:24:46 AM WITA │ root │ latest incremental backup │ backupdir=asdf, subvolid=5, uuid=000000-0000-0000-0000-000000000000
```